### PR TITLE
Typo fixed in README and Nyx\Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A PHP process manager of the night.
 
 ## Getting started
 
-Download the latest .phar from https://steadweb.github.io/nyxgit
+Download the latest .phar from https://steadweb.github.io/nyx
 
 ```
 wget https://steadweb.github.io/nyx/nyx.phar

--- a/src/Nyx/Manager.php
+++ b/src/Nyx/Manager.php
@@ -33,7 +33,7 @@ final class Manager implements OutputableInterface
     /**
      * @string
      */
-    const VERSION = '0.1.0';
+    const VERSION = '0.1.1';
 
     /**
      * @string


### PR DESCRIPTION
[BUG] fixed typo within README and upped version within Nyx\Manager